### PR TITLE
Fix duplicated graph inputs issue

### DIFF
--- a/third_party/blink/renderer/modules/ml/webnn/ml_graph_builder.cc
+++ b/third_party/blink/renderer/modules/ml/webnn/ml_graph_builder.cc
@@ -3140,6 +3140,7 @@ void MLGraphBuilder::SortOperators(
     HeapVector<Member<const MLOperator>>& sorted_operators) {
   HeapDeque<Member<const MLOperator>> operators_to_do;
   HeapHashSet<Member<const MLOperator>> operators_done;
+  HeapHashSet<Member<const MLOperand>> visited_inputs;
   for (const auto& output : named_outputs) {
     operators_to_do.push_back(output.second->Operator());
   }
@@ -3161,7 +3162,11 @@ void MLGraphBuilder::SortOperators(
         // done set.
         for (const auto& input : op->Inputs()) {
           if (input->Kind() == MLOperand::kInput) {
-            inputs.push_back(input.Get());
+            // Add the input if it is not visited.
+            if (!visited_inputs.Contains(input.Get())) {
+              inputs.push_back(input.Get());
+              visited_inputs.insert(input.Get());
+            }
           } else if (input->Kind() == MLOperand::kConstant) {
             constants.push_back(input.Get());
           }


### PR DESCRIPTION
The DirectML prototype uses `MLGraphBuilder::SortOperators()` to sort operators and operands. It doesn't check whether an input operand is visited or not. The duplicated inputs would cause DML backend execution failure. This issue would also help @Honry to unblock the WebNN EP enabling work.

@fdwr @mingmingtasd @fujunwei, PTAL.