### PR TITLE
Fix crash issue when graph has multiple outputs

### DIFF
--- a/content/browser/ml/webnn/dml/graph_dml_impl.cc
+++ b/content/browser/ml/webnn/dml/graph_dml_impl.cc
@@ -1891,6 +1891,8 @@ void GraphDMLImpl::Compute(NamedResourcesPtr named_inputs,
   // outputs from Graph Build, so the offset need to be found the correct output
   // with name to read back from GPU buffer.
   base::flat_map<std::string, DML_BUFFER_BINDING> output_buffer_binding;
+  // Reseve the map capacity to avoid reallocation.
+  output_buffer_binding.reserve(output_length_map.size());
   uint64_t aligned_offset = 0;
   size_t i = 0;
   for (auto& [name, byte_length] : output_length_map) {
@@ -1965,6 +1967,8 @@ bool GraphDMLImpl::Compute(NamedResourcesPtr named_inputs,
   // outputs from Graph Build, so the offset need to be found the correct output
   // with name to read back from GPU buffer.
   base::flat_map<std::string, DML_BUFFER_BINDING> output_buffer_binding;
+  // Reseve the map capacity to avoid reallocation.
+  output_buffer_binding.reserve(output_length_map.size());
   uint64_t aligned_offset = 0;
   size_t i = 0;
   for (auto& [name, byte_length] : output_length_map) {


### PR DESCRIPTION
The root cause is IDMLBindingTable::BindOutputs() use the references to the DML_BUFFER_BINDING objects storaged in base::flat_map<>. These references may become invalid if the flat_map reallocates the storage when adding more outputs.

Fix this issue by reserve the flat_map capacity to avoid the reallocation.