### PR TITLE
Shrink the Gather's output shape

### DIFF
--- a/content/browser/ml/webnn/dml/graph_dml_impl.cc
+++ b/content/browser/ml/webnn/dml/graph_dml_impl.cc
@@ -1255,8 +1255,9 @@ void GraphDMLImpl::AddGather(UINT64 input_index,
 
   graph_desc_builder_->Connect({input_node, indices_node}, {node});
 
-  auto node_output = graph_desc_builder_->CreateNodeOutput(
-      node, 0, std::move(output_expanded_desc));
+  TensorDesc output_origin_desc(input_tensor_desc.GetDataType(), output_dimensions);
+  auto node_output =
+      graph_desc_builder_->CreateNodeOutput(node, 0, std::move(output_origin_desc));
   node_output_map_[output_index] = std::move(node_output);
 }
 


### PR DESCRIPTION
Shrink the Gather's output shape to avoid crash in AddGemm(). For example:

Gather output shape {1, 1, 256} -> shrink to 2d {1, 256}.  Gemm can only support 2d inputs now.